### PR TITLE
Paolo add getImportLines

### DIFF
--- a/src/executable-code/executable-fragment.js
+++ b/src/executable-code/executable-fragment.js
@@ -22,6 +22,7 @@ const KEY_CODES = {
   F9: 120
 };
 const DEBOUNCE_TIME = 500;
+const SEARCH_IMPORT = "import ";
 
 const SELECTORS = {
   CANVAS_PLACEHOLDER_OUTPUT: ".js-code-output-canvas-placeholder",
@@ -312,6 +313,13 @@ export default class ExecutableFragment extends ExecutableCodeTemplate {
     return platform === TargetPlatform.JS
       ? document.body
       : this.nodes[0].querySelector(SELECTORS.CANVAS_PLACEHOLDER_OUTPUT);
+  }
+    
+  getImportLines() {
+      const allSnippet = this.codemirror.getValue().split("\n");
+      const allImportLines = allSnippet.filter(line => line.indexOf(SEARCH_IMPORT) !== -1);
+      
+      return allImportLines;
   }
 
   getCode() {

--- a/src/executable-code/executable-fragment.js
+++ b/src/executable-code/executable-fragment.js
@@ -317,7 +317,7 @@ export default class ExecutableFragment extends ExecutableCodeTemplate {
     
   getImportLines() {
       const allSnippet = this.codemirror.getValue().split("\n");
-      const allImportLines = allSnippet.filter(line => line.indexOf(SEARCH_IMPORT) !== -1);
+      const allImportLines = allSnippet.filter(line => line.includes(SEARCH_IMPORT));
       
       return allImportLines;
   }


### PR DESCRIPTION
This PR adds the `getImportLines` method that separates all lines in a code snippet where it detects an import, in order to place them on top of the final joined snippet to be compiled.
