### PR TITLE
RemoveImports method

### DIFF
--- a/src/executable-code/executable-fragment.js
+++ b/src/executable-code/executable-fragment.js
@@ -315,18 +315,10 @@ export default class ExecutableFragment extends ExecutableCodeTemplate {
       : this.nodes[0].querySelector(SELECTORS.CANVAS_PLACEHOLDER_OUTPUT);
   }
 
-  removeImports (completeSnippet, importSnippet) {
-    let newArr = [];
+  removeImports (completeSnippet) {
+    const noImportsSnippet = completeSnippet.filter(line => !line.includes(SEARCH_IMPORT));
 
-    completeSnippet.map(function(val) {
-      importSnippet.includes(val) ? '' : newArr.push(val);
-    });
-
-    importSnippet.map(function(val) {
-      completeSnippet.includes(val) ? '' : newArr.push(val) ;
-    });
-
-    return newArr;
+    return noImportsSnippet;
   }
 
   getImportLines() {

--- a/src/executable-code/executable-fragment.js
+++ b/src/executable-code/executable-fragment.js
@@ -314,11 +314,25 @@ export default class ExecutableFragment extends ExecutableCodeTemplate {
       ? document.body
       : this.nodes[0].querySelector(SELECTORS.CANVAS_PLACEHOLDER_OUTPUT);
   }
-    
+
+  removeImports (completeSnippet, importSnippet) {
+    let newArr = [];
+
+    completeSnippet.map(function(val) {
+      importSnippet.includes(val) ? '' : newArr.push(val);
+    });
+
+    importSnippet.map(function(val) {
+      completeSnippet.includes(val) ? '' : newArr.push(val) ;
+    });
+
+    return newArr;
+  }
+
   getImportLines() {
       const allSnippet = this.codemirror.getValue().split("\n");
       const allImportLines = allSnippet.filter(line => line.includes(SEARCH_IMPORT));
-      
+
       return allImportLines;
   }
 


### PR DESCRIPTION
This PR adds the `removeImports` method which will be used to compose the whole snippet code to compile. 
The method returns a code snippet without the import lines.
We need this method for the composition of the grouped snippets since there are code snippets that contain import lines that would result in errors when grouping all the snippet instead of having all the imports on top.