### PR TITLE
Contruct executable code incrementally

### DIFF
--- a/src/executable-code/executable-fragment.js
+++ b/src/executable-code/executable-fragment.js
@@ -44,6 +44,7 @@ export default class ExecutableFragment extends ExecutableCodeTemplate {
       'directives': directives
     });
 
+    instance.parent = options.parent ? options.parent : null;
     instance.arrayClasses = [];
     instance.initialized = false;
     instance.state = {

--- a/src/executable-code/executable-fragment.js
+++ b/src/executable-code/executable-fragment.js
@@ -247,11 +247,14 @@ export default class ExecutableFragment extends ExecutableCodeTemplate {
       waitingForOutput: true,
       openConsole: false
     });
+
+    const code = this.state.incremental ? this.getIncModeCode() : this.getCode();
+
     //open when waitingForOutput=true
     if (onOpenConsole) onOpenConsole();
     if (targetPlatform === TargetPlatform.JAVA || targetPlatform === TargetPlatform.JUNIT) {
       WebDemoApi.executeKotlinCode(
-        this.getCode(),
+        code,
         compilerVersion,
         targetPlatform, args,
         theme,
@@ -270,7 +273,7 @@ export default class ExecutableFragment extends ExecutableCodeTemplate {
       )
     } else {
       if (targetPlatform === TargetPlatform.CANVAS) this.jsExecutor.reloadIframeScripts(jsLibs, this.getNodeForMountIframe(targetPlatform));
-      WebDemoApi.translateKotlinToJs(this.getCode(), compilerVersion, targetPlatform, args, hiddenDependencies).then(
+      WebDemoApi.translateKotlinToJs(code, compilerVersion, targetPlatform, args, hiddenDependencies).then(
         state => {
           state.waitingForOutput = false;
           const jsCode = state.jsCode;

--- a/src/executable-code/executable-fragment.js
+++ b/src/executable-code/executable-fragment.js
@@ -316,17 +316,18 @@ export default class ExecutableFragment extends ExecutableCodeTemplate {
       : this.nodes[0].querySelector(SELECTORS.CANVAS_PLACEHOLDER_OUTPUT);
   }
 
-  removeImports (completeSnippet) {
-    const noImportsSnippet = completeSnippet.filter(line => !line.includes(SEARCH_IMPORT));
-
-    return noImportsSnippet;
+  getImportLines() {
+    const completeSnippet = this.getCode().split("\n");
+    return completeSnippet.filter(line =>
+      line.includes(SEARCH_IMPORT))
+      .join("\n");
   }
 
-  getImportLines() {
-      const allSnippet = this.codemirror.getValue().split("\n");
-      const allImportLines = allSnippet.filter(line => line.includes(SEARCH_IMPORT));
-
-      return allImportLines;
+  getCodeWithoutImports () {
+    const completeSnippet = this.getCode().split("\n");
+    return completeSnippet.filter(line =>
+      !line.includes(SEARCH_IMPORT))
+      .join("\n");
   }
 
   getCode() {

--- a/src/executable-code/executable-fragment.js
+++ b/src/executable-code/executable-fragment.js
@@ -23,6 +23,8 @@ const KEY_CODES = {
 };
 const DEBOUNCE_TIME = 500;
 const SEARCH_IMPORT = "import ";
+const WRAPPING_FUNCTION_TOP_LINE = "\nfun main(args: Array<String>) {println({";
+const WRAPPING_FUNCTION_BOTTOM_LINE = "}())}";
 
 const SELECTORS = {
   CANVAS_PLACEHOLDER_OUTPUT: ".js-code-output-canvas-placeholder",
@@ -336,6 +338,42 @@ export default class ExecutableFragment extends ExecutableCodeTemplate {
     } else {
       return this.codemirror.getValue()
     }
+  }
+
+  getIncModeCode() {
+    const previousSnippets = this.parent.instances.slice(0, this.parent.id);
+
+    const previousSnippetsImports = previousSnippets
+      .map(snippet => snippet.view.getImportLines())
+      .filter(line => line.length > 0)
+      .join("\n");
+
+    const previousSnippetsCode = previousSnippets
+      .map(snippet => snippet.view.getCodeWithoutImports())
+      .filter(line => line.length > 0)
+      .join("\n");
+
+    const completeCode = [
+        previousSnippetsCode,
+        this.getCodeWithoutImports()]
+      .filter(line => line.length > 0)
+      .join("\n");
+
+    const wrappedCode =  [
+        WRAPPING_FUNCTION_TOP_LINE,
+        completeCode,
+        WRAPPING_FUNCTION_BOTTOM_LINE]
+      .filter(line => line.length > 0)
+      .join("\n");
+
+    const fullSnippet = [
+        previousSnippetsImports,
+        this.getImportLines(),
+        wrappedCode]
+      .filter(line => line.length > 0)
+      .join("\n");
+
+    return fullSnippet;
   }
 
   recalculatePosition(position) {

--- a/src/executable-code/index.js
+++ b/src/executable-code/index.js
@@ -66,8 +66,9 @@ export default class ExecutableCode {
    * @param {string|HTMLElement} target
    * @param {{compilerVersion: *}} [config]
    * @param {Object} eventFunctions
+   * @param {number} id
    */
-  constructor(target, config = {}, eventFunctions) {
+  constructor(target, config = {}, eventFunctions, id = null) {
     const targetNode = typeof target === 'string' ? document.querySelector(target) : target;
     let executable = targetNode.hasAttribute(ATTRIBUTES.EXECUTABLE);
     const noneMarkers = targetNode.hasAttribute(ATTRIBUTES.NONE_MARKERS);
@@ -125,6 +126,7 @@ export default class ExecutableCode {
       outputHeight
     }, eventFunctions));
 
+    this.id = id;
     this.config = cfg;
     this.node = mountNode;
     this.targetNode = targetNode;
@@ -258,7 +260,7 @@ export default class ExecutableCode {
     return WebDemoApi.getCompilerVersions().then((versions) => {
       const instances = [];
 
-      targetNodes.forEach((node) => {
+      targetNodes.forEach((node, index) => {
         const config = getConfigFromElement(node, true);
         const minCompilerVersion = config.minCompilerVersion;
         let latestStableVersion = null;
@@ -289,7 +291,7 @@ export default class ExecutableCode {
           return;
         }
 
-        instances.push(new ExecutableCode(node, { compilerVersion }, eventFunctions));
+        instances.push(new ExecutableCode(node, { compilerVersion }, eventFunctions, index));
       });
 
       ExecutableCode.prototype.instances = instances;

--- a/src/executable-code/index.js
+++ b/src/executable-code/index.js
@@ -101,7 +101,7 @@ export default class ExecutableCode {
     const mountNode = document.createElement('div');
     insertAfter(mountNode, targetNode);
 
-    const view = ExecutableFragment.render(mountNode);
+    const view = ExecutableFragment.render(mountNode, { parent: this });
     view.update(Object.assign({
       code: code,
       lines: lines,
@@ -291,6 +291,8 @@ export default class ExecutableCode {
 
         instances.push(new ExecutableCode(node, { compilerVersion }, eventFunctions));
       });
+
+      ExecutableCode.prototype.instances = instances;
 
       return instances;
     });

--- a/src/executable-code/index.js
+++ b/src/executable-code/index.js
@@ -70,7 +70,8 @@ export default class ExecutableCode {
    */
   constructor(target, config = {}, eventFunctions, id = null) {
     const targetNode = typeof target === 'string' ? document.querySelector(target) : target;
-    let executable = targetNode.hasAttribute(ATTRIBUTES.EXECUTABLE);
+    let executable = targetNode.getAttribute(ATTRIBUTES.EXECUTABLE) === "true" || targetNode.getAttribute(ATTRIBUTES.EXECUTABLE) === "incremental";
+    const incremental = targetNode.getAttribute(ATTRIBUTES.EXECUTABLE) === "incremental";
     const noneMarkers = targetNode.hasAttribute(ATTRIBUTES.NONE_MARKERS);
     const indent = targetNode.hasAttribute(ATTRIBUTES.INDENT) ? parseInt(targetNode.getAttribute(ATTRIBUTES.INDENT)) : DEFAULT_INDENT;
     const from = targetNode.hasAttribute(ATTRIBUTES.FROM) ? parseInt(targetNode.getAttribute(ATTRIBUTES.FROM)) : null;
@@ -120,6 +121,7 @@ export default class ExecutableCode {
       onFlyHighLight: onFlyHighLight,
       autoIndent: autoIndent,
       executable: executable,
+      incremental: incremental,
       targetPlatform: targetPlatform,
       jsLibs: jsLibs,
       isFoldedButton: isFoldedButton,


### PR DESCRIPTION
* Set parent reference in fragment elements, instances to main class prototype.
* Add `id` reference to each snippet instance, that would be later accessible through the parent reference.
* Adapt current snippet filtering functions to return the code in a similar way to the `getCode()` function.
* Add support for having `incremental` option as value for an executable snippet.
* Add `getIncModeCode` function building code with previous+current snippets.
* Set executable code conditionally depending on the `executable` option (`incremental` or `true`?) set.

This fixes #8 