### PR TITLE
Arrow versioned snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,16 @@ playground('.selector', options)
 
 Use the following attributes on elements that are converted to editors to adjust their behavior.
 
-- `data-version`: Target Kotlin [compiler version](https://try.kotlinlang.org/kotlinServer?type=getKotlinVersions):
+- `data-arrow-version`: Target [Arrow version](https://try.arrow-kt.io:80/kotlinServer?type=getArrowVersions):
+
+   ```html
+    <code data-arrow-version="0.10.0">
+    /*
+    Your code here
+    */
+    </code>
+    ```
+- `data-version`: Target Kotlin [compiler version](https://try.arrow-kt.io:80/kotlinServer?type=getKotlinVersions):
 
    ```html
     <code data-version="1.0.7">

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 ```
 
-<!--
 ### Use from plugins
 
 1) [Kotlin Playground WordPress plugin](https://github.com/Kotlin/kotlin-playground-wp-plugin) — [WordPress](https://wordpress.com/) plugin which allows to embed interactive Kotlin playground to any post.

--- a/README.md
+++ b/README.md
@@ -34,12 +34,13 @@ document.addEventListener('DOMContentLoaded', function() {
 
 You can also overwrite the server where the code will be sent to be compiled and analyzed (for example if you host a server instance that includes your own Kotlin libraries). For that you can set the `data-server` attribute.
 
-And you can also set a default Kotlin version for code snippets to run on. Bear in mind that the [version set per editor](#customizing-editors) will take precedence though:
+And you can also set a default Arrow or Kotlin version for code snippets to run on. Bear in mind that the [versions set per editor](#customizing-editors) will take precedence though:
 
 ```html
 <script src="https://unpkg.com/arrow-playground@1"
         data-selector="code"
         data-server="https://my-arrow-playground-server"
+        data-arrow-version="0.10.0"
         data-version="1.3.41">
 </script>
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arrow-playground",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "description": "Self-contained component to embed in websites for running Kotlin, Arrow library aware, code",
   "keywords": [
     "kotlin",

--- a/src/config.js
+++ b/src/config.js
@@ -20,6 +20,9 @@ export const API_URLS = {
   get COMPLETE() {
     return `${this.server}/kotlinServer?type=complete&runConf=`;
   },
+  get ARROW_VERSIONS() {
+    return `${this.server}/kotlinServer?type=getArrowVersions`;
+  },
   get VERSIONS() {
     return `${this.server}/kotlinServer?type=getKotlinVersions`;
   },

--- a/src/executable-code/executable-fragment.js
+++ b/src/executable-code/executable-fragment.js
@@ -245,7 +245,7 @@ export default class ExecutableFragment extends ExecutableCodeTemplate {
 
   execute() {
     const {
-      onOpenConsole, targetPlatform, waitingForOutput, compilerVersion, onRun, onError,
+      onOpenConsole, targetPlatform, waitingForOutput, arrowVersion, compilerVersion, onRun, onError,
       args, theme, hiddenDependencies, onTestPassed, onTestFailed, onCloseConsole, jsLibs, outputHeight, getJsCode
     } = this.state;
     if (waitingForOutput) {
@@ -263,6 +263,7 @@ export default class ExecutableFragment extends ExecutableCodeTemplate {
     if (targetPlatform === TargetPlatform.JAVA || targetPlatform === TargetPlatform.JUNIT) {
       WebDemoApi.executeKotlinCode(
         code,
+        arrowVersion,
         compilerVersion,
         targetPlatform, args,
         theme,
@@ -283,7 +284,7 @@ export default class ExecutableFragment extends ExecutableCodeTemplate {
       )
     } else {
       this.jsExecutor.reloadIframeScripts(jsLibs, this.getNodeForMountIframe());
-      WebDemoApi.translateKotlinToJs(code, compilerVersion, targetPlatform, args, hiddenDependencies).then(
+      WebDemoApi.translateKotlinToJs(code, arrowVersion, compilerVersion, targetPlatform, args, hiddenDependencies).then(
         state => {
           state.waitingForOutput = false;
           const jsCode = state.jsCode;
@@ -499,6 +500,7 @@ export default class ExecutableFragment extends ExecutableCodeTemplate {
       WebDemoApi.getAutoCompletion(
         code,
         currentCursor,
+        this.state.arrowVersion,
         this.state.compilerVersion,
         this.state.targetPlatform,
         this.state.hiddenDependencies,
@@ -564,6 +566,7 @@ export default class ExecutableFragment extends ExecutableCodeTemplate {
       if (onFlyHighLight) {
         WebDemoApi.getHighlight(
           this.getCode(),
+          arrowversion,
           compilerVersion,
           targetPlatform,
           hiddenDependencies).then(data => this.showDiagnostics(data))

--- a/src/executable-code/executable-fragment.monk
+++ b/src/executable-code/executable-fragment.monk
@@ -45,7 +45,8 @@
     {% if (executable) %}
         <div class="compiler-info">
             <span>Target platform: {{ targetPlatform.printableName }}</span>
-            <span>Running on kotlin v. {{ compilerVersion }}</span>
+            <span>Running on Arrow v. {{ arrowVersion }}</span>
+            <span>Running on Kotlin v. {{ compilerVersion }}</span>
         </div>
     {% endif %}
 

--- a/src/executable-code/index.js
+++ b/src/executable-code/index.js
@@ -104,7 +104,7 @@ export default class ExecutableCode {
     insertAfter(mountNode, targetNode);
 
     const view = ExecutableFragment.render(mountNode, { parent: this, eventFunctions });
-    view.update(Object.assign({
+    view.update(Object.assign(eventFunctions = {}, {
       code: code,
       lines: lines,
       theme: editorTheme,
@@ -127,7 +127,7 @@ export default class ExecutableCode {
       jsLibs: jsLibs,
       isFoldedButton: isFoldedButton,
       outputHeight
-    }, eventFunctions));
+    }));
 
     this.id = id;
     this.config = cfg;
@@ -285,8 +285,7 @@ export default class ExecutableCode {
           const listOfArrowVersions = arrowVersions.map(version => version.version);
           let listOfVersions = versions.map(version => version.version);
 
-          if (listOfVersions.includes(config.version) && listOfArrowVersions.includes(config.arrowVersion)) {
-            arrowVersion = config.arrowVersion;
+          if (listOfVersions.includes(config.version)) {
             compilerVersion = config.version;
           } else if (listOfVersions.includes(options.version)) {
             compilerVersion = options.version;
@@ -296,13 +295,20 @@ export default class ExecutableCode {
                 latestStableVersion = compilerConfig.version;
               }
             });
+            compilerVersion = latestStableVersion;
+          }
+
+          if (listOfArrowVersions.includes(config.arrowVersion)) {
+            arrowVersion = config.arrowVersion;
+          } else if (listOfArrowVersions.includes(options.arrowVersion)) {
+            arrowVersion = options.arrowVersion;
+          } else {
             arrowVersions.forEach((arrowConfig) => {
               if (arrowConfig.latestStable) {
                 arrowLatestStableVersion = arrowConfig.version;
               }
             });
             arrowVersion = arrowLatestStableVersion;
-            compilerVersion = latestStableVersion;
           }
 
           if (minCompilerVersion) {

--- a/src/webdemo-api.js
+++ b/src/webdemo-api.js
@@ -28,6 +28,24 @@ export default class WebDemoApi {
   /**
    * @return {Promise<Array<KotlinVersion>>}
    */
+  static getArrowVersions() {
+    if ('arrowVersions' in CACHE) {
+      return Promise.resolve(CACHE.arrowVersions);
+    }
+
+    return fetch(API_URLS.ARROW_VERSIONS)
+      .then(response => response.json())
+      .then(versions => {
+        CACHE.arrowVersions = versions;
+        return versions;
+      }).catch(() => {
+        return null
+      });
+  }
+
+  /**
+   * @return {Promise<Array<KotlinVersion>>}
+   */
   static getCompilerVersions() {
     if ('compilerVersions' in CACHE) {
       return Promise.resolve(CACHE.compilerVersions);
@@ -47,14 +65,15 @@ export default class WebDemoApi {
    * Request on translation Kotlin code to JS code
    *
    * @param code            - string
+   * @param arrowVersion    - string Arrow version
    * @param compilerVersion - string kotlin compiler
    * @param platform        - TargetPlatform
    * @param args            - command line arguments
    * @param hiddenDependencies   - read only additional files
    * @returns {*|PromiseLike<T>|Promise<T>}
    */
-  static translateKotlinToJs(code, compilerVersion, platform, args, hiddenDependencies) {
-    return executeCode(API_URLS.COMPILE, code, compilerVersion, platform, args, hiddenDependencies).then(function (data) {
+  static translateKotlinToJs(code, arrowVersion, compilerVersion, platform, args, hiddenDependencies) {
+    return executeCode(API_URLS.COMPILE, code, arrowVersion, compilerVersion, platform, args, hiddenDependencies).then(function (data) {
       let output = "";
       let errorsAndWarnings = flatten(Object.values(data.errors));
       return {
@@ -69,6 +88,7 @@ export default class WebDemoApi {
    * Request on execute Kotlin code.
    *
    * @param code            - string
+   * @param arrowVersion    - string Arrow version
    * @param compilerVersion - string kotlin compiler
    * @param platform        - TargetPlatform
    * @param args            - command line arguments
@@ -78,8 +98,8 @@ export default class WebDemoApi {
    * @param hiddenDependencies   - read only additional files
    * @returns {*|PromiseLike<T>|Promise<T>}
    */
-  static executeKotlinCode(code, compilerVersion, platform, args, theme, hiddenDependencies, onTestPassed, onTestFailed) {
-    return executeCode(API_URLS.COMPILE, code, compilerVersion, platform, args, hiddenDependencies).then(function (data) {
+  static executeKotlinCode(code, arrowVersion, compilerVersion, platform, args, theme, hiddenDependencies, onTestPassed, onTestFailed) {
+    return executeCode(API_URLS.COMPILE, code, arrowVersion, compilerVersion, platform, args, hiddenDependencies).then(function (data) {
       let output = "";
       let errorsAndWarnings = flatten(Object.values(data.errors));
       let errors = errorsAndWarnings.filter(error => error.severity === "ERROR");
@@ -114,13 +134,14 @@ export default class WebDemoApi {
    *
    * @param code - string code
    * @param cursor - cursor position in code
+   * @param arrowVersion    - string Arrow version
    * @param compilerVersion - string kotlin compiler
    * @param hiddenDependencies   - read only additional files
    * @param platform - kotlin platform {@see TargetPlatform}
    * @param callback
    */
-  static getAutoCompletion(code, cursor, compilerVersion, platform, hiddenDependencies, callback) {
-    executeCode(API_URLS.COMPLETE, code, compilerVersion, platform, "", hiddenDependencies, cursor)
+  static getAutoCompletion(code, cursor, arrowVersion, compilerVersion, platform, hiddenDependencies, callback) {
+    executeCode(API_URLS.COMPLETE, code, arrowVersion, compilerVersion, platform, "", hiddenDependencies, cursor)
       .then(data => {
         callback(data);
       })
@@ -130,24 +151,26 @@ export default class WebDemoApi {
    * Request for getting errors of current file
    *
    * @param code - string code
+   * @param arrowVersion    - string Arrow version
    * @param compilerVersion - string kotlin compiler
    * @param platform - kotlin platform {@see TargetPlatform}
    * @param hiddenDependencies   - read only additional files
    * @return {*|PromiseLike<T>|Promise<T>}
    */
-  static getHighlight(code, compilerVersion, platform, hiddenDependencies) {
-    return executeCode(API_URLS.HIGHLIGHT, code, compilerVersion, platform, "", hiddenDependencies)
+  static getHighlight(code, arrowVersion, compilerVersion, platform, hiddenDependencies) {
+    return executeCode(API_URLS.HIGHLIGHT, code, arrowVersion, compilerVersion, platform, "", hiddenDependencies)
       .then(data => data[DEFAULT_FILE_NAME])
   }
 }
 
-function executeCode(url, code, compilerVersion, targetPlatform, args, hiddenDependencies, options) {
+function executeCode(url, code, arrowVersion, compilerVersion, targetPlatform, args, hiddenDependencies, options) {
   const files = [buildFileObject(code, DEFAULT_FILE_NAME)]
     .concat(hiddenDependencies.map((file, index) => buildFileObject(file, `hiddenDependency${index}.kt`)));
   const projectJson = JSON.stringify({
     "id": "",
     "name": "",
     "args": args,
+    "arrowVersion": arrowVersion,
     "compilerVersion": compilerVersion,
     "confType": targetPlatform.id,
     "originUrl": null,


### PR DESCRIPTION
Mimicking the `version` attribute, this PR adds the feature of setting an specific Arrow version for the snippet code to be compiled with. This is done through the `arrow-version` attribute, that can be set per code editor, or by setting a default one when Arrow Playground is initialized.