### PR TITLE
Add Arrow latest version usage support

### DIFF
--- a/src/executable-code/index.js
+++ b/src/executable-code/index.js
@@ -268,6 +268,7 @@ export default class ExecutableCode {
       targetNodes.forEach((node, index) => {
         const config = getConfigFromElement(node, true);
         const minCompilerVersion = config.minCompilerVersion;
+        let arrowLatestVersion = null;
         let arrowLatestStableVersion = null;
         let arrowVersion = null;
         let latestStableVersion = null;
@@ -307,8 +308,11 @@ export default class ExecutableCode {
               if (arrowConfig.latestStable) {
                 arrowLatestStableVersion = arrowConfig.version;
               }
+              if (arrowConfig.latest) {
+                arrowLatestVersion = arrowConfig.version;
+              }
             });
-            arrowVersion = arrowLatestStableVersion;
+            arrowVersion = ((config.arrowVersion === "latest" || options.arrowVersion === "latest") && arrowLatestVersion) ? arrowLatestVersion : arrowLatestStableVersion;
           }
 
           if (minCompilerVersion) {


### PR DESCRIPTION
* Add Arrow latest version usage support.

---

given a backend response like this:

```json
[
  {
    "version": "0.8.2",
    "supportedKotlinVersions": [
      "1.2.71",
      "1.3.41",
      "1.3.50"
    ],
    "latest": false,
    "latestStable": false
  },
  {
    "version": "0.9.0",
    "supportedKotlinVersions": [
      "1.2.71",
      "1.3.41",
      "1.3.50"
    ],
    "latest": false,
    "latestStable": false
  },
  {
    "version": "0.10.3",
    "supportedKotlinVersions": [
      "1.2.71",
      "1.3.41",
      "1.3.50"
    ],
    "latest": false,
    "latestStable": true
  },
  {
    "version": "0.10.4-SNAPSHOT",
    "supportedKotlinVersions": [
      "1.2.71",
      "1.3.41",
      "1.3.50"
    ],
    "latest": true,
    "latestStable": false
  }
]
```

This will make Arrow Playground to use the latest Arrow version indicated by the backend when we are setting `latest` as the Arrow version to use.

```html
<script src="arrow-playground.js" data-arrow-version="latest"></script>
```